### PR TITLE
fixing #6 pip install zscaler-sdk not valid

### DIFF
--- a/ZIA/claude-zscaler-integration/README.md
+++ b/ZIA/claude-zscaler-integration/README.md
@@ -8,7 +8,7 @@ This tool allows Claude Desktop to interact with Zscaler Internet Access (ZIA) A
 2. Claude Desktop application
 3. Zscaler Internet Access (ZIA) account with API access
 4. Required Python packages:
-   - `zscaler-sdk` - Install with `pip install zscaler-sdk`
+   - `zscaler-sdk-python` - Install with `pip install zscaler-sdk`
    - `fastmcp` - Install with `pip install fastmcp`
 
 ## File Structure


### PR DESCRIPTION
Committer: Jonathan Jesse  <jjesse@gmail.com>

This should resolve #6 as the README calls pip install zscaler-sdk when it should be pip install zscaler-sdk-python